### PR TITLE
Ensure that we treat timestamps as UTC no matter what the local system time is

### DIFF
--- a/pskreporter-sender
+++ b/pskreporter-sender
@@ -17,7 +17,7 @@ Options:
 
 from pskreporter import PskReporter
 import re
-from datetime import datetime, time
+from datetime import datetime, time, timezone
 import subprocess
 from docopt import docopt
 import sys
@@ -156,6 +156,8 @@ def submit(stream, pskreporter, mode):
 
 if __name__ == "__main__":
     args = docopt(__doc__)
+
+    logging.warning(f"Starting pskreporter-sender with args {args}")
 
     file = args["<logfile>"]
     mode = args["<mode>"]

--- a/pskreporter.py
+++ b/pskreporter.py
@@ -45,6 +45,8 @@ class PskReporter(object):
         self.uploader = Uploader(self.station, tcp=tcp)
         self.timer = None
         self.dummy = dummy
+        self.total_spots = 0
+        
 
     def getOldSpots(self):
         cutoff = time.time() - 1200
@@ -134,8 +136,10 @@ class PskReporter(object):
                         f"Dropping {spot_count - len(spots)} spots as too old (without connectivity). {len(spots)} left."
                     )
                 if spots:
+                    self.total_spots += len(spots)
                     unsent = self.uploader.upload(spots)
                     if unsent:
+                        self.total_spots -= len(unsent)
                         # We want to save these for later
                         with self.spotLock:
                             self.spots = unsent + self.spots
@@ -153,6 +157,7 @@ class PskReporter(object):
         self.upload()
         if self.spots:
             logging.warning(f"Failed to upload {len(self.spots)} spots on close")
+        logging.warning("Uploaded {self.total_spots} spots total")
 
 
 class Uploader(object):

--- a/pskreporter.py
+++ b/pskreporter.py
@@ -157,7 +157,7 @@ class PskReporter(object):
         self.upload()
         if self.spots:
             logging.warning(f"Failed to upload {len(self.spots)} spots on close")
-        logging.warning("Uploaded {self.total_spots} spots total")
+        logging.warning(f"Uploaded {self.total_spots} spots total")
 
 
 class Uploader(object):


### PR DESCRIPTION
Make sure that we parse datetimes in UTC. Also add start/end log messages with a spot count.