### PR TITLE
Make it handle lines not matching the pattern better (and not throw an exception)

### DIFF
--- a/pskreporter-sender
+++ b/pskreporter-sender
@@ -90,7 +90,7 @@ def do_wspr(stream, pskreporter, mode):
                     locator=m.group("locator"),
                     hexbytes=raw_hex,
                 )
-            elif not line.startswith(b"<Decode"):
+            elif not line.startswith("<Decode"):
                 print(line)
         except Exception as e:
             logging.error(f"Failed to create spot ({e}): {original_line}")


### PR DESCRIPTION
It turned out that it would throw an exception if it came across a record in the wspr log that didn't match one of the patterns. This didn't actually hurt anything.