### PR TITLE
Remove snr reporting as it wasn't reporting the snr anyway!

### DIFF
--- a/pskreporter-sender
+++ b/pskreporter-sender
@@ -97,8 +97,9 @@ def do_wspr(stream, pskreporter, mode):
 
 
 def submit(stream, pskreporter, mode):
+    # It turns out that the field that I thought was snr is actually a score and is fairly unrelated to snr.
     r = re.compile(
-        r"(?P<ts>[0-9/]+ [0-9:]+) +(?P<snr>[-0-9]+) +(?P<dt>[-+.0-9]+) (?P<freq>[0-9,.]+) ~ (?P<msg>.*)$"
+        r"(?P<ts>[0-9/]+ [0-9:]+) +(?P<score>[-0-9]+) +(?P<dt>[-+.0-9]+) (?P<freq>[0-9,.]+) ~ (?P<msg>.*)$"
     )
     cq = re.compile(
         r"CQ (DX )?(?P<callsign>[A-Z0-9][A-Z0-9/-]+[A-Z0-9]) (?P<locator>[A-Z][A-Z][0-9][0-9]) *$"
@@ -138,7 +139,6 @@ def submit(stream, pskreporter, mode):
                     ts = datetime.strptime(
                         m.group("ts"), "%Y/%m/%d %H:%M:%S"
                     ).replace(tzinfo=timezone.utc).timestamp()
-                    snr = -int(m.group("snr"))
                     freq = float(m.group("freq").replace(",", ""))
 
                     pskreporter.spot(
@@ -146,7 +146,6 @@ def submit(stream, pskreporter, mode):
                         mode=mode,
                         timestamp=ts,
                         frequency=freq,
-                        db=snr,
                         locator=match.group("locator"),
                         hexbytes=raw_hex,
                     )

--- a/pskreporter.py
+++ b/pskreporter.py
@@ -316,7 +316,7 @@ class Uploader(object):
         antennaInformation = (
             self.station["antenna"] if "antenna" in self.station else ""
         )
-        decodingSoftware = "N1DQ-KA9Q-Radio/1.2"
+        decodingSoftware = "N1DQ-KA9Q-Radio/1.3"
 
         body = [
             b

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pskreporter-sender"
-version = "1.0.0"  # Update with your program's version
+version = "1.3.0"  # Update with your program's version
 description = "PSK Reporter Sender"
 
 [build-system]


### PR DESCRIPTION
It turned out that the field that I thought was the snr was actually a score -- which is sort of related to the snr, but not in a good enough way.

This PR removes the reporting of the snr. It turned out that PSKReporter also didn't handle the nulls well either, so that had to be fixed as well.